### PR TITLE
Bug Fix `episode list filter`

### DIFF
--- a/src/components/EpisodeLinks/EpisodeLinksList.js
+++ b/src/components/EpisodeLinks/EpisodeLinksList.js
@@ -33,6 +33,10 @@ const EpisodeLinksList = ({ episodeArray, episodeNum }) => {
         buffer[key] = rangeValues;
       }
       setRangeFilters(buffer);
+      if(episodeNum === 0){
+        setCurrentRange(Object.keys(buffer)[0]);
+        return;
+      }
       const rangeIndex = Math.floor((episodeNum - 1) / 100);
       setCurrentRange(Object.keys(buffer)[rangeIndex]);
     };


### PR DESCRIPTION
#### SUMMARY
Fixes a bug in #63. 

#### BUG DESCRIPTION
When no data is returned from localStorage for an anime in AnimeDetails page, the episodeNum is 0, which prevents rendering of episodes due to negative indexes in setCurrentRange.

This PR fixes the above bug by adding a condition to check for value 0 as episodeNum and setting the CurrentRange accordingly.