### PR TITLE
Fix VideoPlayer fetching after unmount

### DIFF
--- a/src/components/VideoPlayer/VideoPlayer.js
+++ b/src/components/VideoPlayer/VideoPlayer.js
@@ -39,8 +39,9 @@ function VideoPlayer({ sources, internalPlayer, setInternalPlayer, title }) {
       ],
     };
 
+    let hls;
     if (Hls.isSupported()) {
-      const hls = new Hls();
+      hls = new Hls();
       hls.loadSource(src);
       hls.attachMedia(video);
 
@@ -205,6 +206,10 @@ function VideoPlayer({ sources, internalPlayer, setInternalPlayer, title }) {
         ],
       };
     }
+    return () => {
+      hls.stopLoad();
+      hls.destroy();
+    };
   }, [src, title]);
 
   return (
@@ -246,6 +251,5 @@ function VideoPlayer({ sources, internalPlayer, setInternalPlayer, title }) {
     </div>
   );
 }
-
 
 export default VideoPlayer;


### PR DESCRIPTION
SUMMARY:
For now, this cleanup function fixes the issue in all the cases I've tested. Since, the video player logic is complex, other edge cases might arise where this might not work. I'd like you to look into it as well.
```js
  return () => {
      hls.stopLoad();
      hls.destroy();
    };
```
ISSUE:
Fixes #69 (nice)