### PR TITLE
Enhanced `Continue watching`

### DIFF
--- a/src/components/Home/WatchingEpisodes.js
+++ b/src/components/Home/WatchingEpisodes.js
@@ -95,7 +95,6 @@ function WatchingEpisodes() {
       lsData.Names.splice(index, 1);
       lsData = JSON.stringify(lsData);
       localStorage.setItem("Animes", lsData);
-      // data.splice(index, 1);
       setData((data) => [...data.slice(0, index), ...data.slice(index + 1)]);
       setConfirmRemove([...confirmRemove.slice(0, index), ...confirmRemove.slice(index + 1)]);
     } else {

--- a/src/components/Home/WatchingEpisodes.js
+++ b/src/components/Home/WatchingEpisodes.js
@@ -29,13 +29,13 @@ let searchAnimeQuery = `
 	}
 `;
 
-function WatchingEpisodes({ change, setChange }) {
+function WatchingEpisodes() {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     getData();
-  }, [change]);
+  }, []);
 
   async function getData() {
     setLoading(true);
@@ -90,8 +90,11 @@ function WatchingEpisodes({ change, setChange }) {
     lsData.Names.splice(index, 1);
     lsData = JSON.stringify(lsData);
     localStorage.setItem("Animes", lsData);
-    data.splice(index, 1);
-    setChange(!change);
+    // data.splice(index, 1);
+    setData(data => [
+      ...data.slice(0, index),
+      ...data.slice(index + 1),
+    ]);
   }
 
   return (

--- a/src/components/Home/WatchingEpisodes.js
+++ b/src/components/Home/WatchingEpisodes.js
@@ -201,6 +201,7 @@ const ConfirmRemove = styled.div`
 const Wrapper = styled.div`
   position: relative;
   button {
+    font-family: 'Gilroy-Regular', sans-serif;
     cursor: pointer;
     outline: none;
     border: none;
@@ -208,9 +209,6 @@ const Wrapper = styled.div`
     padding: 0.5rem;
     border-radius: 0.2rem;
     background-color: rgba(0, 0, 0, 0.7);
-    &+button {
-      margin-left: 0.5rem;
-    }
   }
   .removeButton {
     border-top-left-radius: 0.5rem;

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -11,7 +11,6 @@ import WatchingEpisodes from "../components/Home/WatchingEpisodes";
 function Home() {
   const [images, setImages] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [change, setChange] = useState(false);
   const { width } = useWindowDimensions();
 
   useEffect(() => {
@@ -50,7 +49,7 @@ function Home() {
                 <span>Continue</span> Watching
               </Heading>
             </HeadingWrapper>
-            <WatchingEpisodes change={change} setChange={setChange} />
+            <WatchingEpisodes />
           </div>
         )}
         <div>


### PR DESCRIPTION
I noticed that the continue watching items reloaded whenever an item was removed.
Instead of forcing an entire reload the state can simply be updated.
I also added a confirmation and fixed the episode number display (text was not visible)
![image](https://user-images.githubusercontent.com/10459377/193569122-e791da90-24c5-4249-bae1-5dea1d0bf2bb.png)
![image](https://user-images.githubusercontent.com/10459377/193569164-104fead0-7c26-46b3-b696-24ff292a52bf.png)
