### PR TITLE
Fix `404 Page`

### DIFF
--- a/src/pages/PageNotFound.js
+++ b/src/pages/PageNotFound.js
@@ -1,18 +1,122 @@
 import React from "react";
+import { Link } from "react-router-dom";
 // import logo from "./public/assets/img/ghost.png";
 import styled from "styled-components";
 
 function PageNotFound() {
-    return (
-        <div class="pageNotFound">
-                        <img src="https://cdn.discordapp.com/attachments/928341740434378752/1016160204355813437/3.png" width="320" alt="Akio" ></img>
-                        <div class="errorMessage">
-                            <p class="err">ERROR</p>
-                            <p class="num"> 404</p>
-                            <h1>Looks like you are lost...</h1>
-                        </div>
-        </div>
-    );
-};
+  return (
+    <NotFoundWrapper>
+      <ErrorCTA>
+        <img
+          src="https://cdn.discordapp.com/attachments/928341740434378752/1016160204355813437/3.png"
+          width="320"
+          alt="Akio"
+          className="error-image"
+        />
+        <HomeLink to="/">Go to Home</HomeLink>
+      </ErrorCTA>
+      <ErrorDetails>
+        <h2 className="error-code">404</h2>
+        <p className="error-status">Page Not Found</p>
+        <h1 className="error-message">Looks like you are lost...</h1>
+      </ErrorDetails>
+    </NotFoundWrapper>
+  );
+}
+
+const NotFoundWrapper = styled.div`
+  display: flex;
+  height: 100%;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  margin: auto auto;
+  padding: 10px 10px;
+  gap: 20px;
+  text-align: center;
+  @media screen and (max-width: 1024px) {
+    flex-direction: column-reverse;
+  }
+`;
+
+const ErrorCTA = styled.div`
+  position: relative;
+  width: 350px;
+  overflow: hidden;
+  .error-image {
+    width: 100%;
+    object-fit: cover;
+    margin-left: 15px;
+    object-position: center;
+  }
+  @media screen and (max-width: 380px) {
+    width: 100%;
+  }
+`;
+
+const HomeLink = styled(Link)`
+  background-color: #FFFFFF;
+  color: #23272A;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 10px 0%;
+  border-radius: 10px;
+  text-decoration: none;
+  font-weight: bold;
+  font-size: 22px;
+  @media screen and (max-width: 380px) {
+    width: 100%;
+    font-size: 16px;
+  }
+`;
+
+const ErrorDetails = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-content: center;
+  gap: 1rem;
+  white-space: pre-wrap;
+
+  .error-code {
+    font-size: 120px;
+    letter-spacing: 10px;
+    color: white;
+  }
+  .error-status {
+    font-size: 100px;
+    color: white;
+  }
+  .error-message {
+    color: gray;
+  }
+  @media screen and (max-width: 1024px) {
+    .error-code {
+      font-size: 80px;
+    }
+    .error-status {
+      font-size: 70px;
+    }
+    .error-message {
+      font-size: 30px;
+    }
+  }
+  @media screen and (max-width: 600px) {
+    .error-code {
+      font-size: 60px;
+    }
+    .error-status {
+      font-size: 40px;
+    }
+    .error-message {
+      font-size: 20px;
+    }
+  }
+  @media screen and (max-width: 380px) {
+
+  }
+`;
 
 export default PageNotFound;

--- a/src/styles/globalStyles.js
+++ b/src/styles/globalStyles.js
@@ -28,7 +28,7 @@ const GlobalStyle = createGlobalStyle`
 	/* Firefox */
   * {
     scrollbar-width: thin;
-    scrollbar-color: #4f4f4f #141414;
+    scrollbar-color: #4F4F4F #141414;
   }
 
   /* Chrome, Edge, and Safari */
@@ -41,9 +41,9 @@ const GlobalStyle = createGlobalStyle`
   }
 
   *::-webkit-scrollbar-thumb {
-    background-color: #4f4f4f;
+    background-color: #4F4F4F;
     border-radius: 10px;
-    border: 0px none #ffffff;
+    border: 0px none #FFFFFF;
   }
 
 	.swiper-pagination-bullet-active {
@@ -101,40 +101,6 @@ const GlobalStyle = createGlobalStyle`
 		cursor: pointer;
 		background-color: rgba(0, 0, 0, 0.6);
 		color: #FFFFFF;
-	}
-	.pageNotFound{
-		display:flex;
-		flex-direction:row;
-		margin-left:auto;
-		margin-right:auto;
-		align-conetnt:center;
-	}
-	.errorMessage
-	{
-		display:flex;
-		flex-direction: column;
-		justify-content: flex-start;
-		align-content: center;
-
-	}
-
-	.err
-	{
-		font-size:100px;
-		color: white;
-
-
-	}
-
-	.num
-	{
-		font-size:160px; 
-		letter-spacing:10px;
-		color: white;
-	}
-
-	.errorMessage h1{
-		color: grey;
 	}
 `;
 


### PR DESCRIPTION
#### SUMMARY
The 404 page was not responsive and used global styles. This PR uses styled components to make the 404-page responsive.

#### ISSUE
This improves upon some critical mistakes in #74. 

#### LIST OF CHANGES
1. Remove global styles for PageNotFound.
2. Change class to className in jsx.
3. Use Styled components for styling.
4. Add media queries to make the page responsive.
5. Add a 'Go to Home' button. 