### PR TITLE
Fixed `Dynamic Page Titles`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "react-dom": "^18.2.0",
         "react-icons": "^4.4.0",
         "react-loading-skeleton": "^3.1.0",
-        "react-router-dom": "^6.4.1",
+        "react-router-dom": "^6.4.0",
         "react-scripts": "5.0.1",
         "scripts": "^0.1.0",
         "styled-components": "^5.3.6",

--- a/src/App.js
+++ b/src/App.js
@@ -11,22 +11,27 @@ import TrendingAnime from "./pages/TrendingAnime";
 import WatchAnime from "./pages/WatchAnime";
 import GlobalStyle from "./styles/globalStyles";
 import PageNotFound from "./pages/PageNotFound";
+import { useState } from "react";
 
 function App() {
+  const [metaArr, setMetaArr] = useState({"title": "Sakamoto - Watch Popular Anime Online", "description": "Sakamoto. An ad-free anime streaming site. Catch your favourite shows and movies right here! Help us by contributing to the project on github."})
+  function changeMetaArr(propertyChanged, change){
+    document.title = change
+  }
   return (
     <Router>
       <GlobalStyle />
       <Nav />
       <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/popular" element={<PopularAnime />} />
-        <Route path="/trending" element={<TrendingAnime />} />
-        <Route path="/favourites" element={<FavouriteAnime />} />
-        <Route path="/top100" element={<Top100Anime />} />
-        <Route path="/search/:name" element={<SearchResults />} />
-        <Route path="/category/:slug" element={<AnimeDetails />} />
-        <Route path="/watch/:episode" element={<WatchAnime />} />
-        <Route path="*" element={<PageNotFound />}/>
+        <Route path="/" element={<Home changeMetaArr={changeMetaArr} />} />
+        <Route path="/popular" element={<PopularAnime changeMetaArr={changeMetaArr} />} />
+        <Route path="/trending" element={<TrendingAnime changeMetaArr={changeMetaArr} />} />
+        <Route path="/favourites" element={<FavouriteAnime changeMetaArr={changeMetaArr} />} />
+        <Route path="/top100" element={<Top100Anime changeMetaArr={changeMetaArr} />} />
+        <Route path="/search/:name" element={<SearchResults changeMetaArr={changeMetaArr} />} />
+        <Route path="/category/:slug" element={<AnimeDetails changeMetaArr={changeMetaArr} />} />
+        <Route path="/watch/:episode" element={<WatchAnime changeMetaArr={changeMetaArr} />} />
+        <Route path="*" element={<PageNotFound changeMetaArr={changeMetaArr}/>}/>
       </Routes>
       <Footer />
     </Router>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -7,13 +7,16 @@ import AnimeCards from "../components/Home/AnimeCards";
 import HomeSkeleton from "../components/skeletons/CarouselSkeleton";
 import useWindowDimensions from "../hooks/useWindowDimensions";
 import WatchingEpisodes from "../components/Home/WatchingEpisodes";
-
-function Home() {
+import {metaContext} from '../App'
+function Home({changeMetaArr}) {
   const [images, setImages] = useState([]);
   const [loading, setLoading] = useState(true);
   const [confirmRemove, setConfirmRemove] = useState([]);
   const { width } = useWindowDimensions();
-
+  React.useEffect(()=>{
+    changeMetaArr("title", "Sakamoto - Watch Popular Anime Online")
+    // console.log("Hlo")
+  })
   useEffect(() => {
     getImages();
   }, []);

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -7,7 +7,7 @@ import AnimeCards from "../components/Home/AnimeCards";
 import HomeSkeleton from "../components/skeletons/CarouselSkeleton";
 import useWindowDimensions from "../hooks/useWindowDimensions";
 import WatchingEpisodes from "../components/Home/WatchingEpisodes";
-import {metaContext} from '../App'
+
 function Home({changeMetaArr}) {
   const [images, setImages] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/pages/PageNotFound.js
+++ b/src/pages/PageNotFound.js
@@ -3,7 +3,10 @@ import { Link } from "react-router-dom";
 // import logo from "./public/assets/img/ghost.png";
 import styled from "styled-components";
 
-function PageNotFound() {
+function PageNotFound({changeMetaArr}) {
+  React.useEffect(()=>{
+    changeMetaArr("title", "PageNotFound")
+  })
   return (
     <NotFoundWrapper>
       <ErrorCTA>

--- a/src/pages/PopularAnime.js
+++ b/src/pages/PopularAnime.js
@@ -3,13 +3,17 @@ import React, { useEffect, useState } from "react";
 import AnimeGrid from "../components/AnimeGrid/AnimeGrid";
 import SearchResultsSkeleton from "../components/skeletons/SearchResultsSkeleton";
 
-function PopularAnime() {
+function PopularAnime({changeMetaArr}) {
   const [animeDetails, setAnimeDetails] = useState([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     getAnime();
   }, []);
+
+  React.useEffect(()=>{
+    changeMetaArr("title", "Popular Anime")
+  })
 
   async function getAnime() {
     window.scrollTo(0, 0);

--- a/src/pages/SearchResults.js
+++ b/src/pages/SearchResults.js
@@ -10,13 +10,15 @@ const DefaultFilter = {
 };
 
 
-function SearchResults() {
+function SearchResults({changeMetaArr}) {
   let urlParams = useParams().name;
   urlParams = urlParams.replace(":", "").replace("(", "").replace(")", "");
   const [results, setResults] = useState([]);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState(DefaultFilter);
-
+  React.useEffect(()=>{
+    changeMetaArr("title", `Search results for: ${urlParams}`)
+  })
   useEffect(() => {
     async function getResults() {
       setLoading(true);

--- a/src/pages/Top100Anime.js
+++ b/src/pages/Top100Anime.js
@@ -3,14 +3,16 @@ import React, { useEffect, useState } from "react";
 import AnimeGrid from "../components/AnimeGrid/AnimeGrid";
 import SearchResultsSkeleton from "../components/skeletons/SearchResultsSkeleton";
 
-function Top100Anime() {
+function Top100Anime({changeMetaArr}) {
   const [animeDetails, setAnimeDetails] = useState([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     getAnime();
   }, []);
-
+  React.useEffect(()=>{
+    changeMetaArr("title", "Top 100 Anime")
+  })
   async function getAnime() {
     window.scrollTo(0, 0);
     let res = await axios.get(

--- a/src/pages/TrendingAnime.js
+++ b/src/pages/TrendingAnime.js
@@ -3,14 +3,16 @@ import React, { useEffect, useState } from "react";
 import AnimeGrid from "../components/AnimeGrid/AnimeGrid";
 import SearchResultsSkeleton from "../components/skeletons/SearchResultsSkeleton";
 
-function TrendingAnime() {
+function TrendingAnime({changeMetaArr}) {
   const [animeDetails, setAnimeDetails] = useState([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     getAnime();
   }, []);
-
+  React.useEffect(()=>{
+    changeMetaArr("title", "Trending Anime")
+  })
   async function getAnime() {
     window.scrollTo(0, 0);
     let res = await axios.get(

--- a/src/pages/WatchAnime.js
+++ b/src/pages/WatchAnime.js
@@ -13,7 +13,7 @@ import ServersList from "../components/WatchAnime/ServersList";
 import PlayerContainer from "../components/Wrappers/PlayerContainer";
 import EpisodeLinksList from "../components/EpisodeLinks/EpisodeLinksList";
 
-function WatchAnime() {
+function WatchAnime({changeMetaArr}) {
   let episodeSlug = useParams().episode;
 
   const [episodeLinks, setEpisodeLinks] = useState([]);
@@ -119,6 +119,20 @@ function WatchAnime() {
       document.exitFullscreen();
     }
   }
+
+  useEffect(()=>{
+    if(loading===false){
+      changeMetaArr("title", `${episodeLinks[0].titleName.substring(
+        0,
+        episodeLinks[0].titleName.indexOf("Episode")
+      )} - ${" " +
+      episodeLinks[0].titleName.substring(
+        episodeLinks[0].titleName.indexOf("Episode")
+      )}`)
+      console.log("Hello")
+    }
+  }, [loading])
+
   return (
     <div>
       {loading && <WatchAnimeSkeleton />}


### PR DESCRIPTION
Closes #64 Dynamic page titles.
Made a global meta array state and changed it in different pages. Meta array has support for changing the meta descriptions too.
![Screenshot_20221006_022602](https://user-images.githubusercontent.com/95919665/194162079-2899f77a-1db1-4740-9ab5-ccc7eb4a8910.png)
![Screenshot_20221006_022619](https://user-images.githubusercontent.com/95919665/194162086-bba6b1d9-eae2-4bdf-9b22-c31905920938.png)
![Screenshot_20221006_022639](https://user-images.githubusercontent.com/95919665/194162091-e4866412-5e87-40d5-84c5-fa1b4546be6f.png)
![Screenshot_20221006_022647](https://user-images.githubusercontent.com/95919665/194162092-77de28a6-f50b-43b5-bc9c-c9391e71720e.png)
