### PR TITLE
`video player` refactor

### DIFF
--- a/src/components/VideoPlayer/VideoPlayer.js
+++ b/src/components/VideoPlayer/VideoPlayer.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useMemo, useCallback} from "react";
+import React, { useEffect, useState, useRef} from "react";
 import { HiOutlineSwitchHorizontal } from "react-icons/hi";
 import { BsSkipEnd } from "react-icons/bs";
 import { IconContext } from "react-icons";
@@ -51,7 +51,6 @@ function VideoPlayer({ sources, internalPlayer, setInternalPlayer, title }) {
     }
 
     function createPlayer() {
-
       const newPlayer = new plyr(videoRef?.current, defaultOptions);
 
       setPlayer(new plyr(videoRef?.current, defaultOptions));
@@ -113,7 +112,6 @@ function VideoPlayer({ sources, internalPlayer, setInternalPlayer, title }) {
 
     let hls;
     if (Hls.isSupported()) {
-
       hls = new Hls();
       hls.loadSource(src);
       hls.attachMedia(videoRef?.current);


### PR DESCRIPTION
Back with another PR for Hacktoberfest!

I did further refactoring of the `VideoPlayer` component to make it more DRY as I noticed there was a lot of repeated code. Also, I reverted some of what I originally changed, specifically with the direct DOM manipulation after learning more about `plyr`.

Please note: In case you weren't already aware, sometimes there is a double render of the video element on the initial load. [You have `React.StrictMode` wrapped around your App, which is the cause of this](https://stackoverflow.com/questions/62324139/why-is-my-react-component-rendering-twice-on-initial-load). It only will be noticeable on your dev environment, not production. Removing it also makes the double render go away. I tested it and it works fine when removed. 